### PR TITLE
Update datapack to 1.21.8 and fix menu toggles

### DIFF
--- a/data/commands/functions/slimetools/admintp.mcfunction
+++ b/data/commands/functions/slimetools/admintp.mcfunction
@@ -1,5 +1,5 @@
-execute unless score ST st1 matches 0 run scoreboard players set ST st1 1
-execute unless score ST st1 matches 1 run scoreboard players set ST st1 0
+scoreboard players add ST st1 1
+execute if score ST st1 matches 2.. run scoreboard players set ST st1 0
 
 execute if score ST st1 matches 0 run tellraw @s {"text":"AdminTP Disabled","color":"purple"}
 execute if score ST st1 matches 1 run tellraw @s {"text":"AdminTp Enabled","color":"purple"}

--- a/data/commands/functions/slimetools/book_announce.mcfunction
+++ b/data/commands/functions/slimetools/book_announce.mcfunction
@@ -1,5 +1,5 @@
-execute unless score ST st5 matches 0 run scoreboard players set ST st5 1
-execute unless score ST st5 matches 1 run scoreboard players set ST st5 0
+scoreboard players add ST st5 1
+execute if score ST st5 matches 2.. run scoreboard players set ST st5 0
 
 execute if score ST st5 matches 0 run tellraw @s {"text":"Book Announcer Disabled","color":"purple"}
 execute if score ST st5 matches 1 run tellraw @s {"text":"Book Announcer Enabled","color":"purple"}

--- a/data/commands/functions/slimetools/dragonegg.mcfunction
+++ b/data/commands/functions/slimetools/dragonegg.mcfunction
@@ -1,5 +1,5 @@
-execute unless score ST st9 matches 0 run scoreboard players set ST st9 1
-execute unless score ST st9 matches 1 run scoreboard players set ST st9 0
+scoreboard players add ST st9 1
+execute if score ST st9 matches 2.. run scoreboard players set ST st9 0
 
 execute if score ST st9 matches 0 run tellraw @s {"text":"Dragon Egg Challenge Disabled","color":"purple"}
 execute if score ST st9 matches 1 run tellraw @s {"text":"Dragon Egg Challenge Enabled","color":"purple"}

--- a/data/commands/functions/slimetools/fixsound.mcfunction
+++ b/data/commands/functions/slimetools/fixsound.mcfunction
@@ -1,5 +1,5 @@
-execute unless score ST st7 matches 0 run scoreboard players set ST st7 1
-execute unless score ST st7 matches 1 run scoreboard players set ST st7 0
+scoreboard players add ST st7 1
+execute if score ST st7 matches 2.. run scoreboard players set ST st7 0
 
 execute if score ST st7 matches 0 run tellraw @s {"text":"FixSound Disabled","color":"purple"}
 execute if score ST st7 matches 1 run tellraw @s {"text":"FixSound Enabled","color":"purple"}

--- a/data/commands/functions/slimetools/forceload.mcfunction
+++ b/data/commands/functions/slimetools/forceload.mcfunction
@@ -1,5 +1,5 @@
-execute unless score ST st2 matches 0 run scoreboard players set ST st2 1
-execute unless score ST st2 matches 1 run scoreboard players set ST st2 0
+scoreboard players add ST st2 1
+execute if score ST st2 matches 2.. run scoreboard players set ST st2 0
 
 execute if score ST st2 matches 0 run tellraw @s {"text":"Forceload Disabled","color":"purple"}
 execute if score ST st2 matches 1 run tellraw @s {"text":"Forceload Enabled","color":"purple"}

--- a/data/commands/functions/slimetools/keehan_death.mcfunction
+++ b/data/commands/functions/slimetools/keehan_death.mcfunction
@@ -1,5 +1,5 @@
-execute unless score ST st11 matches 0 run scoreboard players set ST st11 1
-execute unless score ST st11 matches 1 run scoreboard players set ST st11 0
+scoreboard players add ST st11 1
+execute if score ST st11 matches 2.. run scoreboard players set ST st11 0
 
 execute if score ST st11 matches 0 run tellraw @s {"text":"Keehan Death Disabled","color":"purple"}
 execute if score ST st11 matches 1 run tellraw @s {"text":"Keehan Death Enabled","color":"purple"}

--- a/data/commands/functions/slimetools/remove_kbook.mcfunction
+++ b/data/commands/functions/slimetools/remove_kbook.mcfunction
@@ -1,5 +1,5 @@
-execute unless score ST st4 matches 0 run scoreboard players set ST st4 1
-execute unless score ST st4 matches 1 run scoreboard players set ST st4 0
+scoreboard players add ST st4 1
+execute if score ST st4 matches 2.. run scoreboard players set ST st4 0
 
 execute if score ST st4 matches 0 run tellraw @s {"text":"kBook Remover Disabled","color":"purple"}
 execute if score ST st4 matches 1 run tellraw @s {"text":"kBook Remover Enabled","color":"purple"}

--- a/data/commands/functions/slimetools/removepetrified.mcfunction
+++ b/data/commands/functions/slimetools/removepetrified.mcfunction
@@ -1,5 +1,5 @@
-execute unless score ST st7 matches 0 run scoreboard players set ST st7 1
-execute unless score ST st7 matches 1 run scoreboard players set ST st7 0
+scoreboard players add ST st7 1
+execute if score ST st7 matches 2.. run scoreboard players set ST st7 0
 
 execute if score ST st7 matches 0 run tellraw @s {"text":"Petrified Slab Remover Disabled","color":"purple"}
 execute if score ST st7 matches 1 run tellraw @s {"text":"Petrified Slab Remover Enabled","color":"purple"}

--- a/data/commands/functions/slimetools/slitem_warning.mcfunction
+++ b/data/commands/functions/slimetools/slitem_warning.mcfunction
@@ -1,5 +1,5 @@
-execute unless score ST stGround matches 0 run scoreboard players set ST stGround 1
-execute unless score ST stGround matches 1 run scoreboard players set ST stGround 0
+scoreboard players add ST stGround 1
+execute if score ST stGround matches 2.. run scoreboard players set ST stGround 0
 
 execute if score ST stGround matches 0 run tellraw @s {"text":"Special Item Effects Disabled","color":"purple"}
 execute if score ST stGround matches 1 run tellraw @s {"text":"Special Item Effects Enabled","color":"purple"}

--- a/data/commands/functions/slimetools/spawntp.mcfunction
+++ b/data/commands/functions/slimetools/spawntp.mcfunction
@@ -1,5 +1,5 @@
-execute unless score ST st3 matches 0 run scoreboard players set ST st3 1
-execute unless score ST st3 matches 1 run scoreboard players set ST st3 0
+scoreboard players add ST st3 1
+execute if score ST st3 matches 2.. run scoreboard players set ST st3 0
 
 execute if score ST st3 matches 0 run tellraw @s {"text":"SpawnTP Disabled","color":"purple"}
 execute if score ST st3 matches 1 run tellraw @s {"text":"SpawnTP Enabled","color":"purple"}

--- a/data/commands/functions/slimetools/spawntptardis.mcfunction
+++ b/data/commands/functions/slimetools/spawntptardis.mcfunction
@@ -1,5 +1,5 @@
-execute unless score ST st6 matches 0 run scoreboard players set ST st6 1
-execute unless score ST st6 matches 1 run scoreboard players set ST st6 0
+scoreboard players add ST st6 1
+execute if score ST st6 matches 2.. run scoreboard players set ST st6 0
 
 execute if score ST st6 matches 0 run tellraw @s {"text":"Tardis Locked at Spawn Disabled","color":"purple"}
 execute if score ST st6 matches 1 run tellraw @s {"text":"Tardis Locked at Spawn Enabled","color":"purple"}

--- a/data/commands/functions/slimetools/special_item.mcfunction
+++ b/data/commands/functions/slimetools/special_item.mcfunction
@@ -1,5 +1,5 @@
-execute unless score ST st12 matches 0 run scoreboard players set ST st12 1
-execute unless score ST st12 matches 1 run scoreboard players set ST st12 0
+scoreboard players add ST st12 1
+execute if score ST st12 matches 2.. run scoreboard players set ST st12 0
 
 execute if score ST st12 matches 0 run tellraw @s {"text":"Special Item Effects Disabled","color":"purple"}
 execute if score ST st12 matches 1 run tellraw @s {"text":"Special Item Effects Enabled","color":"purple"}

--- a/data/commands/functions/slimetools/tardis_item_delete.mcfunction
+++ b/data/commands/functions/slimetools/tardis_item_delete.mcfunction
@@ -1,5 +1,5 @@
-execute unless score ST st12 matches 0 run scoreboard players set ST st12 1
-execute unless score ST st12 matches 1 run scoreboard players set ST st12 0
+scoreboard players add ST st12 1
+execute if score ST st12 matches 2.. run scoreboard players set ST st12 0
 
 execute if score ST st12 matches 0 run tellraw @s {"text":"Tardis Egg Deleter Disabled","color":"purple"}
 execute if score ST st12 matches 1 run tellraw @s {"text":"Tardis Egg Deleter Enabled","color":"purple"}

--- a/pack.mcmeta
+++ b/pack.mcmeta
@@ -1,6 +1,6 @@
 {
   "pack": {
-    "pack_format": 15,
+    "pack_format": 81,
     "description": "SlimeTools Datapack"
   }
 }


### PR DESCRIPTION
## Summary
- bump the datapack pack.mcmeta to Minecraft 1.21.8's pack format
- refactor each menu toggle function to use add-and-clamp scoreboard logic so the toggles reliably flip states

## Testing
- not run (datapack changes only)


------
https://chatgpt.com/codex/tasks/task_e_68d6cd0001b0832f863994dca98d82fd